### PR TITLE
Fix bad encoding

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,6 +59,7 @@ function register (server, options, next) {
   })
 
   server.on('request', function (request, event) {
+    request.logger = request.logger || logger.child({ req: request })
     logEvent(request.logger, event)
   })
 

--- a/test.js
+++ b/test.js
@@ -182,6 +182,25 @@ experiment('logs each request', () => {
     })
   })
 
+  test('handles bad encoding', (done) => {
+    const server = getServer()
+    server.route({
+      path: '/',
+      method: 'GET',
+      handler: (req, reply) => reply('')
+    })
+    registerWithSink(server, 'info', (data, enc) => {
+      expect(data.data.header).equal('a;b')
+      done()
+    }, (err) => {
+      expect(err).to.be.undefined()
+      server.inject({
+        url: '/',
+        headers: { 'accept-encoding': 'a;b' }
+      })
+    })
+  })
+
   test('set the request logger', (done) => {
     const server = getServer()
     let count = 0


### PR DESCRIPTION
Hey,

I was testing my apply with hapi 16.1.1,  specifically, the way it handles invalid accept-encoding error since accept-encoding.

Looks like this is not working, because, when hapi is checking the error, it does `request.log`.
But at this point, the logger is not yet attached to the request, that is why it fails.

```
TypeError: Cannot read property 'error' of undefined
    at logEvent (PROJECT/node_modules/hapi-pino/index.js:106:16)
    at PROJECT/node_modules/hapi-pino/index.js:64:5
    at invoke (PROJECT/node_modules/hapi/node_modules/podium/lib/index.js:239:30)
    at each (PROJECT/node_modules/hapi/node_modules/podium/lib/index.js:243:13)
    at Object.exports.parallel (PROJECT/node_modules/hapi/node_modules/items/lib/index.js:70:13)
    at Object.internals.emit (PROJECT/node_modules/hapi/node_modules/podium/lib/index.js:260:18)
    at internals.Podium._emit (PROJECT/node_modules/hapi/node_modules/podium/lib/index.js:140:15)
    at each (PROJECT/node_modules/hapi/node_modules/podium/lib/index.js:181:47)
    at Object.exports.parallel (PROJECT/node_modules/hapi/node_modules/items/lib/index.js:70:13)
    at relay (PROJECT/node_modules/hapi/node_modules/podium/lib/index.js:182:15)```

This PR fix the problem.
I made a test to show the problem. It probably can be improved, at least shows that it does nto crash any more with my fix.