### PR TITLE
Add possibility to define custom serializers for req, res and err

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ server.register(require('hapi-pino'), (err) => {
 events"](#hapievents) section.
 
 ### Options
-
+- `[logPayload]` – when enabled, add the request payload as `payload` to the `response` event log. Defaults to `false`.
 - `[stream]` - the binary stream to write stuff to, defaults to
   `process.stdout`.
 - `[prettyPrint]` - pretty print the logs (same as `node server |

--- a/index.js
+++ b/index.js
@@ -13,9 +13,9 @@ module.exports.levelTags = {
 
 function register (server, options, next) {
   options.serializers = options.serializers || {}
-  options.serializers.req = asReqValue
-  options.serializers.res = pino.stdSerializers.res
-  options.serializers.err = pino.stdSerializers.err
+  options.serializers.req = options.serializers.req || asReqValue
+  options.serializers.res = options.serializers.res || pino.stdSerializers.res
+  options.serializers.err = options.serializers.err || pino.stdSerializers.err
 
   if (options.logEvents === undefined) {
     options.logEvents = ['onPostStart', 'onPostStop', 'response', 'request-error']
@@ -57,6 +57,11 @@ function register (server, options, next) {
   // set a logger for each request
   server.ext('onRequest', (request, reply) => {
     request.logger = logger.child({ req: request })
+    reply.continue()
+  })
+
+  server.ext('onPreHandler', (request, reply) => {
+    request.logger = (request.logger || logger).child({ req: request })
     reply.continue()
   })
 

--- a/index.js
+++ b/index.js
@@ -60,11 +60,6 @@ function register (server, options, next) {
     reply.continue()
   })
 
-  server.ext('onPreHandler', (request, reply) => {
-    request.logger = (request.logger || logger).child({ req: request })
-    reply.continue()
-  })
-
   server.on('log', function (event) {
     logEvent(logger, event)
   })
@@ -86,6 +81,7 @@ function register (server, options, next) {
   tryAddEvent(server, options, 'on', 'response', function (request) {
     const info = request.info
     request.logger.info({
+      payload: options.logPayload ? request.payload : undefined,
       res: request.raw.res,
       responseTime: info.responded - info.received
     }, 'request completed')

--- a/test.js
+++ b/test.js
@@ -619,7 +619,7 @@ experiment('logging with overridden serializer', () => {
   test('with pre-defined req serializer', (done) => {
     const server = getServer()
     const stream = sink((data) => {
-      expect(data.req.payload).to.equal({ foo: 42 })
+      expect(data.req.uri).to.equal('/')
       done()
     })
     const logger = require('pino')(stream)
@@ -628,7 +628,7 @@ experiment('logging with overridden serializer', () => {
       options: {
         instance: logger,
         serializers: {
-          req: (req) => ({ payload: req.payload })
+          req: (req) => ({ uri: req.raw.req.url })
         }
       }
     }
@@ -636,11 +636,8 @@ experiment('logging with overridden serializer', () => {
     server.register(plugin, (err) => {
       expect(err).to.be.undefined()
       server.inject({
-        method: 'POST',
-        url: '/',
-        payload: {
-          foo: 42
-        }
+        method: 'GET',
+        url: '/'
       })
     })
   })
@@ -648,7 +645,7 @@ experiment('logging with overridden serializer', () => {
   test('with pre-defined res serializer', (done) => {
     const server = getServer()
     const stream = sink((data) => {
-      expect(data.res.code).to.equal(200)
+      expect(data.res.code).to.equal(404)
       done()
     })
     const logger = require('pino')(stream)
@@ -665,11 +662,8 @@ experiment('logging with overridden serializer', () => {
     server.register(plugin, (err) => {
       expect(err).to.be.undefined()
       server.inject({
-        method: 'POST',
-        url: '/',
-        payload: {
-          foo: 42
-        }
+        method: 'GET',
+        url: '/'
       })
     })
   })
@@ -696,6 +690,35 @@ experiment('logging with overridden serializer', () => {
       server.inject({
         method: 'GET',
         url: '/error'
+      })
+    })
+  })
+})
+
+experiment('logging with request payload', () => {
+  test('with pre-defined req serializer', (done) => {
+    const server = getServer()
+    const stream = sink((data) => {
+      expect(data.payload).to.equal({ foo: 42 })
+      done()
+    })
+    const logger = require('pino')(stream)
+    const plugin = {
+      register: Pino.register,
+      options: {
+        instance: logger,
+        logPayload: true
+      }
+    }
+
+    server.register(plugin, (err) => {
+      expect(err).to.be.undefined()
+      server.inject({
+        method: 'POST',
+        url: '/',
+        payload: {
+          foo: 42
+        }
       })
     })
   })


### PR DESCRIPTION
Related to #13 

- Add possibility to define custom serializers
- Add option `logPayload` to log request payload