### PR TITLE
Fix Hapi Event Handling and Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ events"](#hapievents) section.
 - `[instance]` - uses a previously created Pino instance as the logger.
   The instance's `stream` and `serializers` take precedence.
 - `[logEvents]` - Takes an array of strings with the events to log. Default is to
-  log all events e.g. `['onPostStart', 'onPostStop', 'response', 'request-error']`.
+  log all events e.g. `['onPostStart', 'onPostStop', 'response', 'request']`.
   Set to `false/null` to disable all events.
 - `[mergeHapiLogData]` - When enabled, Hapi-pino will merge the data received
   from Hapi's logging interface (`server.log(tags, data)` or `request.log(tags, data)`)

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ server.log(['info'], {hello: 'world'})
 
 * `'onRequest'`, to create a request-specific child logger
 * `'response'`, to log at `'info'` level when a request is completed
-* `'request'`, to support logging via the Hapi `request.log()` method and to log at `'warn'` level when a request errors for `accept-encoding` tags, see `tags` and `allTags` options.
+* `'request'`, to support logging via the Hapi `request.log()` method, to log when request received contains an invalid `accept-encoding` header and to log at `'warn'` level when a request errors, see `tags` and `allTags` options.
 * `'log'`, to support logging via the Hapi `server.log()` method and to log in case of an internal server event, see `tags` and `allTags` options.
 * `'onPostStart'`, to log when the server is started
 * `'onPostStop'`, to log when the server is stopped

--- a/README.md
+++ b/README.md
@@ -95,8 +95,8 @@ events"](#hapievents) section.
 - `[instance]` - uses a previously created Pino instance as the logger.
   The instance's `stream` and `serializers` take precedence.
 - `[logEvents]` - Takes an array of strings with the events to log. Default is to
-  log all events e.g. `['onPostStart', 'onPostStop', 'response', 'request']`.
-  Set to `false/null` to disable all events.
+  log all events e.g. `['onPostStart', 'onPostStop', 'response', 'request-error']`.
+  Set to `false/null` to disable all events. Even though there is no `request-error` [Hapi Event](#hapievents), the options enables the logging of failed requests.
 - `[mergeHapiLogData]` - When enabled, Hapi-pino will merge the data received
   from Hapi's logging interface (`server.log(tags, data)` or `request.log(tags, data)`)
   into Pino's logged attributes at root level. If data is a string, it will be used as

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ server.log(['info'], {hello: 'world'})
 
 * `'onRequest'`, to create a request-specific child logger
 * `'response'`, to log at `'info'` level when a request is completed
-* `'request'`, to support logging via the Hapi `request.log()` method, to log when request received contains an invalid `accept-encoding` header and to log at `'warn'` level when a request errors, see `tags` and `allTags` options.
+* `'request'`, to support logging via the Hapi `request.log()` method and to log at `'warn'` level when a request errors or when request received contains an invalid `accept-encoding` header, see `tags` and `allTags` options.
 * `'log'`, to support logging via the Hapi `server.log()` method and to log in case of an internal server event, see `tags` and `allTags` options.
 * `'onPostStart'`, to log when the server is started
 * `'onPostStop'`, to log when the server is stopped

--- a/README.md
+++ b/README.md
@@ -134,10 +134,8 @@ server.log(['info'], {hello: 'world'})
 
 * `'onRequest'`, to create a request-specific child logger
 * `'response'`, to log at `'info'` level when a request is completed
-* `'request'`, to log at `'warn'` level when a request errors for
-  `internal` and `accept-encoding` tags
-* `'log'`, to support logging via the Hapi `server.log()` and
-  `request.log()` methods, see `tags` and `allTags` options.
+* `'request'`, to support logging via the Hapi `request.log()` method and to log at `'warn'` level when a request errors for `accept-encoding` tags, see `tags` and `allTags` options.
+* `'log'`, to support logging via the Hapi `server.log()` method and to log in case of an internal server event, see `tags` and `allTags` options.
 * `'onPostStart'`, to log when the server is started
 * `'onPostStop'`, to log when the server is stopped
 


### PR DESCRIPTION
#33 
- fix description of `logEvents` options
- enable obligatory logging of `request.log()`; just the logging of errored requests is optional.
--> backward compatibility with `v1.x.x`

#31 
- fix description of `log` event
- fix description of `request` event