### PR TITLE
apply default serializer.req before using configured serializer.req

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ async function register (server, options) {
     options.serializers.req = (req) => {
       return oriqReqSerializer(asReqValue(req))
     }
-  } else {
+  } else if (options.serializers.req !== null) {
     options.serializers.req = asReqValue
   }
   options.serializers.res = options.serializers.res || pino.stdSerializers.res

--- a/index.js
+++ b/index.js
@@ -14,7 +14,14 @@ const levelTags = {
 
 async function register (server, options) {
   options.serializers = options.serializers || {}
-  options.serializers.req = options.serializers.req || asReqValue
+  if (options.serializers.req) {
+    const oriqReqSerializer = options.serializers.req
+    options.serializers.req = (req) => {
+      return oriqReqSerializer(asReqValue(req))
+    }
+  } else {
+    options.serializers.req = asReqValue
+  }
   options.serializers.res = options.serializers.res || pino.stdSerializers.res
   options.serializers.err = options.serializers.err || pino.stdSerializers.err
 

--- a/index.js
+++ b/index.js
@@ -15,9 +15,9 @@ const levelTags = {
 async function register (server, options) {
   options.serializers = options.serializers || {}
   if (options.serializers.req) {
-    const oriqReqSerializer = options.serializers.req
+    const origReqSerializer = options.serializers.req
     options.serializers.req = (req) => {
-      return oriqReqSerializer(asReqValue(req))
+      return origReqSerializer(asReqValue(req))
     }
   } else if (options.serializers.req !== null) {
     options.serializers.req = asReqValue

--- a/test.js
+++ b/test.js
@@ -755,6 +755,36 @@ experiment('logging with overridden serializer', () => {
     await finish
   })
 
+  test('with req serializer set to null', async () => {
+    const server = getServer()
+    let done
+    const finish = new Promise(function (resolve, reject) {
+      done = resolve
+    })
+    const stream = sink((data) => {
+      expect(data.req.uri).to.not.equal('/')
+      expect(data.req.raw).to.be.an.object()
+      done()
+    })
+    const logger = require('pino')(stream)
+    const plugin = {
+      plugin: Pino,
+      options: {
+        instance: logger,
+        serializers: {
+          req: null
+        }
+      }
+    }
+
+    await server.register(plugin)
+    await server.inject({
+      method: 'GET',
+      url: '/'
+    })
+    await finish
+  })
+
   test('with pre-defined res serializer', async () => {
     const server = getServer()
     let done

--- a/test.js
+++ b/test.js
@@ -742,7 +742,7 @@ experiment('logging with overridden serializer', () => {
       options: {
         instance: logger,
         serializers: {
-          req: (req) => ({ uri: req.raw.req.url })
+          req: (req) => ({ uri: req.url })
         }
       }
     }


### PR DESCRIPTION
This serializes the `req` using the internal `asReqValue` before passing the result to any configured `serializer.req`. This is to make it work in combination with `pino-noir` and a configuration redacting a value in the `req` object. e.g.
```
{
    plugin: require('hapi-pino'),
    options: {
      serializers: noir(['req.headers.authorization'])
    }
  }
```

It is inspired by the discussion in this issue: https://github.com/pinojs/express-pino-logger/issues/14

This change is BC breaking as before any configured serializer got the original `req` object without being passed through `asReqValue`. One test case is changed to reflect this.

I am not sure if this makes sense. Another solution would be to do this within a function passed to
`options.serializers.req` directly. Although this would slightly complicate the usage of `pino-noir` together with this plugin.

I am also not sure if this should be done for `res` as well and if you would like to see this as copied code (just for `res` instead of `req`) or if you prefer to have it in a separate function called with `res` or `req` returning the function.

Let me know if I should change anything.