### PR TITLE
feat(route-tags): logs route tags if options.logRouteTags is true

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ events"](#hapievents) section.
 
 ### Options
 - `[logPayload]` – when enabled, add the request payload as `payload` to the `response` event log. Defaults to `false`.
+- `[logRouteTags]` – when enabled, add the request route tags (as configured in hapi `route.options.tags`) `tags` to the `response` event log. Defaults to `false`.
 - `[stream]` - the binary stream to write stuff to, defaults to
   `process.stdout`.
 - `[prettyPrint]` - pretty print the logs (same as `node server |

--- a/index.js
+++ b/index.js
@@ -99,6 +99,7 @@ async function register (server, options) {
     const info = request.info
     request.logger.info({
       payload: options.logPayload ? request.payload : undefined,
+      tags: options.logRouteTags ? request.route.settings.tags : undefined,
       res: request.raw.res,
       responseTime: info.responded - info.received
     }, 'request completed')


### PR DESCRIPTION
This allows the tags in hapi `route.options.tags` to be part of the logged data. This is useful to e.g. classify the requests in a dashboard.

two tests are added testing for the correct behaviour in both cases `logRouteTags: true` and the absence of this option property.