### PR TITLE
log error with server.log

### DIFF
--- a/index.js
+++ b/index.js
@@ -80,7 +80,7 @@ async function register (server, options) {
   server.events.on('log', function (event) {
     if (event.error) {
       logger.warn({ err: event.error })
-    } else if (event.channel === 'app') {
+    } else {
       logEvent(logger, event)
     }
   })

--- a/index.js
+++ b/index.js
@@ -78,7 +78,11 @@ async function register (server, options) {
   })
 
   server.events.on('log', function (event) {
-    logEvent(logger, event)
+    if (event.error) {
+      logger.warn({ err: event.error })
+    } else if (event.channel === 'app') {
+      logEvent(logger, event)
+    }
   })
 
   // log via `request.log()` and optionally when an internal `accept-encoding`

--- a/test.js
+++ b/test.js
@@ -314,6 +314,26 @@ experiment('logs through server.log', () => {
     await done
   })
 
+  test('with logged error object', async () => {
+    const server = getServer()
+    let resolver
+    const done = new Promise((resolve, reject) => {
+      resolver = resolve
+    })
+
+    await tagsWithSink(server, {}, (data) => {
+      expect(data.err.type).to.equal('Error')
+      expect(data.err.message).to.equal('foobar')
+      expect(data.err.stack).to.exist()
+      // highest level tag
+      expect(data.level).to.equal(40)
+      resolver()
+    })
+
+    server.log(['error'], new Error('foobar'))
+    await done
+  })
+
   test('one log for multiple tags', async () => {
     const server = getServer()
     let resolver


### PR DESCRIPTION
Add the handling of errors logged with `server.log()` — those get ignored up to now.
Adjust the behavior to `request.log()`