### PR TITLE
wrap custom serializers

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,14 @@ events"](#hapievents) section.
   mappings. The default level tags are exposed via `hapi-pino.levelTags`.
 - `[allTags]` - the logging level to apply to all tags not matched by
   `tags`, defaults to `'info'`.
+- `[serializers]` - an object to overwrite the default serializers. You can but don't have to overwrite all of them. E.g. to redact the authorization header in the logs:
+  ```
+  {
+    req: require('pino-noir')(['req.headers.authorization'])
+    res: ...
+    err: ...
+  }
+  ```
 - `[instance]` - uses a previously created Pino instance as the logger.
   The instance's `stream` and `serializers` take precedence.
 - `[logEvents]` - Takes an array of strings with the events to log. Default is to
@@ -103,17 +111,16 @@ events"](#hapievents) section.
   into Pino's logged attributes at root level. If data is a string, it will be used as
   the value for the `msg` key. Default is `false`, in which case data will be logged under 
   a `data` key.
+    E.g.
+  ```js
+  server.log(['info'], {hello: 'world'})
 
-  E.g.
-```js
-server.log(['info'], {hello: 'world'})
+  // with mergeHapiLogData: true
+  { level: 30, hello: 'world', ...}
 
-// with mergeHapiLogData: true
-{ level: 30, hello: 'world', ...}
-
-// with mergeHapiLogData: false (Default)
-{ level: 30, data: { hello: 'world' }}
-```
+  // with mergeHapiLogData: false (Default)
+  { level: 30, data: { hello: 'world' }}
+  ```
 
 <a name="serverdecorations"></a>
 ### Server Decorations

--- a/index.js
+++ b/index.js
@@ -14,8 +14,8 @@ const levelTags = {
 
 async function register (server, options) {
   options.serializers = options.serializers || {}
-  options.serializers.req = options.serializers.req || asReqValue
-  options.serializers.res = options.serializers.res || pino.stdSerializers.res
+  options.serializers.req = wrapReqSerializer(options.serializers.req || asReqValue)
+  options.serializers.res = wrapResSerializer(options.serializers.res || asResValue)
   options.serializers.err = options.serializers.err || pino.stdSerializers.err
 
   if (options.logEvents === undefined) {
@@ -171,15 +171,111 @@ async function register (server, options) {
   }
 }
 
+var rawSymbol = Symbol.for('hapi-pino-raw-ref')
+var pinoReqProto = Object.create({}, {
+  id: {
+    enumerable: true,
+    writable: true,
+    value: ''
+  },
+  method: {
+    enumerable: true,
+    writable: true,
+    value: ''
+  },
+  url: {
+    enumerable: true,
+    writable: true,
+    value: ''
+  },
+  headers: {
+    enumerable: true,
+    writable: true,
+    value: {}
+  },
+  remoteAddress: {
+    enumerable: true,
+    writable: true,
+    value: ''
+  },
+  remotePort: {
+    enumerable: true,
+    writable: true,
+    value: ''
+  },
+  raw: {
+    enumerable: false,
+    get: function () {
+      return this[rawSymbol]
+    },
+    set: function (val) {
+      this[rawSymbol] = val
+    }
+  }
+})
+Object.defineProperty(pinoReqProto, rawSymbol, {
+  writable: true,
+  value: {}
+})
+
+function wrapReqSerializer (serializer) {
+  if (serializer === asReqValue) return asReqValue
+  return function wrappedReqSerializer (req) {
+    return serializer(asReqValue(req))
+  }
+}
+
 function asReqValue (req) {
   const raw = req.raw.req
-  return {
-    id: req.info.id,
-    method: raw.method,
-    url: raw.url,
-    headers: raw.headers,
-    remoteAddress: raw.connection.remoteAddress,
-    remotePort: raw.connection.remotePort
+  const _req = Object.create(pinoReqProto)
+  _req.id = req.info.id
+  _req.method = raw.method
+  _req.url = raw.url
+  _req.headers = raw.headers
+  _req.remoteAddress = raw.connection && raw.connection.remoteAddress
+  _req.remotePort = raw.connection && raw.connection.remotePort
+  _req.raw = req.raw
+  return _req
+}
+
+var pinoResProto = Object.create({}, {
+  statusCode: {
+    enumerable: true,
+    writable: true,
+    value: 0
+  },
+  header: {
+    enumerable: true,
+    writable: true,
+    value: ''
+  },
+  raw: {
+    enumerable: false,
+    get: function () {
+      return this[rawSymbol]
+    },
+    set: function (val) {
+      this[rawSymbol] = val
+    }
+  }
+})
+Object.defineProperty(pinoResProto, rawSymbol, {
+  writable: true,
+  value: {}
+})
+
+function asResValue (res) {
+  const _res = Object.create(pinoResProto)
+  _res.statusCode = res.statusCode
+  _res.header = res._header
+  _res.raw = res
+  return _res
+}
+
+function wrapResSerializer (serializer) {
+  if (serializer === asResValue) return asResValue
+  return function wrappedResSerializer (res) {
+    return serializer(asResValue(res))
   }
 }
 


### PR DESCRIPTION
This wraps custom serializers in the same way as implemented in https://github.com/pinojs/pino-http/pull/43.

This PR replaces https://github.com/pinojs/hapi-pino/pull/34.

Most of the code is copied from the implementation in https://github.com/pinojs/pino-http/pull/43 with small adjustments for hapi specific things.

Tests are updated to test for the existence of `req.raw` and `res.raw` in custom serializers.