### PR TITLE
Backport ignorePaths support to v2.x.x

### DIFF
--- a/index.js
+++ b/index.js
@@ -153,7 +153,7 @@ function asReqValue (req) {
   }
 }
 
-module.exports = {
-  register,
-  name: 'hapi-pino'
+module.exports.register = register
+module.exports.register.attributes = {
+  pkg: require('./package')
 }

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const pino = require('pino')
+const nullLogger = require('abstract-logging')
 
 const levels = ['trace', 'debug', 'info', 'warn', 'error']
 module.exports.levelTags = {
@@ -38,10 +39,9 @@ function register (server, options, next) {
   if (!validTags || (allTags && levels.indexOf(allTags) < 0)) {
     return next(new Error('invalid tag levels'))
   }
-  var nullLogger
+
   var ignoreTable = {}
   if (options.ignorePaths) {
-    nullLogger = buildNullLogger(levels)
     for (let i = 0; i < options.ignorePaths.length; i++) {
       ignoreTable[options.ignorePaths[i]] = true
     }
@@ -151,18 +151,6 @@ function asReqValue (req) {
     remoteAddress: raw.connection.remoteAddress,
     remotePort: raw.connection.remotePort
   }
-}
-
-function buildNullLogger (levels) {
-  var logger = {}
-
-  var noop = function () { }
-
-  for (let i = 0; i < levels.length; i++) {
-    logger[levels[i]] = noop
-  }
-
-  return logger
 }
 
 module.exports = {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "standard": "^10.0.0"
   },
   "dependencies": {
+    "abstract-logging": "^1.0.0",
     "pino": "^4.10.2"
   },
   "repository": {

--- a/test.js
+++ b/test.js
@@ -721,3 +721,39 @@ experiment('logging with request payload', () => {
     })
   })
 })
+
+experiment('ignore request logs for paths in ignorePaths', () => {
+  test('when path matches entry in ignorePaths, nothing should be logged', async () => {
+    const server = getServer()
+    let resolver
+    const done = new Promise((resolve, reject) => {
+      resolver = resolve
+    })
+    const stream = sink((data) => {
+      expect(data.req.url).to.not.equal('/ignored')
+      resolver()
+    })
+    const logger = require('pino')(stream)
+    const plugin = {
+      plugin: Pino,
+      options: {
+        instance: logger,
+        ignorePaths: ['/ignored']
+      }
+    }
+
+    await server.register(plugin)
+
+    await server.inject({
+      method: 'PUT',
+      url: '/ignored'
+    })
+
+    await server.inject({
+      method: 'PUT',
+      url: '/'
+
+    })
+    await done
+  })
+})


### PR DESCRIPTION
This adds the `ignorePaths` option by cherry-picking the commits from PR #30 and adapting for Hapi V16