### PR TITLE
Add support for hapi v18

### DIFF
--- a/index.js
+++ b/index.js
@@ -115,7 +115,7 @@ async function register (server, options) {
       payload: options.logPayload ? request.payload : undefined,
       tags: options.logRouteTags ? request.route.settings.tags : undefined,
       res: request.raw.res,
-      responseTime: info.responded - info.received
+      responseTime: (info.completed !== undefined ? info.completed : info.responded) - info.received
     }, 'request completed')
   })
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "code": "^5.2.4",
     "coveralls": "^3.0.2",
     "flush-write-stream": "^1.0.3",
-    "hapi": "^17.8.1",
+    "hapi": "^18.0.0",
     "lab": "^18.0.0",
     "make-promises-safe": "^4.0.0",
     "pre-commit": "^1.1.2",


### PR DESCRIPTION
I've had a go at fixing #69 which adds support for hapi v18.
The test i've added fails when using v17 and passes with v18.

I've copied the abort logic from [this test](https://github.com/hapijs/hapi/blob/master/test/request.js#L211) in hapi as I couldn't see how to simulate this with `server.inject`.