### PR TITLE
update ignorePaths logic

### DIFF
--- a/index.js
+++ b/index.js
@@ -70,7 +70,7 @@ async function register (server, options) {
 
   // set a logger for each request
   server.ext('onRequest', (request, h) => {
-    if (options.ignorePaths && ignoreTable[request.url.path]) {
+    if (options.ignorePaths && ignoreTable[request.url.pathname]) {
       request.logger = nullLogger
       return h.continue
     }
@@ -106,7 +106,7 @@ async function register (server, options) {
 
   // log when a request completes
   tryAddEvent(server, options, 'on', 'response', function (request) {
-    if (options.ignorePaths && ignoreTable[request.url.path]) {
+    if (options.ignorePaths && ignoreTable[request.url.pathname]) {
       return
     }
 

--- a/test.js
+++ b/test.js
@@ -1001,7 +1001,7 @@ experiment('ignore request logs for paths in ignorePaths', () => {
       resolver = resolve
     })
     const stream = sink((data) => {
-      expect(data.req.url).to.not.equal('/ignored')
+      expect(data.req.url).to.endWith('/foo')
       resolver()
     })
     const logger = require('pino')(stream)
@@ -1022,7 +1022,7 @@ experiment('ignore request logs for paths in ignorePaths', () => {
 
     await server.inject({
       method: 'PUT',
-      url: '/'
+      url: '/foo'
 
     })
     await done
@@ -1037,8 +1037,8 @@ experiment('ignore response logs for paths in ignorePaths', () => {
       resolver = resolve
     })
     const stream = sink((data) => {
+      expect(data.req.url).to.endWith('/foo')
       expect(data.msg).to.equal('request completed')
-      expect(data.req.url).to.not.equal('/ignored')
       resolver()
     })
     const logger = require('pino')(stream)
@@ -1060,7 +1060,7 @@ experiment('ignore response logs for paths in ignorePaths', () => {
 
     await server.inject({
       method: 'PUT',
-      url: '/'
+      url: '/foo'
 
     })
     await done


### PR DESCRIPTION
According to the hapi 18 release notes, `request.url.path` has gone away in favor of `request.path` or `request.url.pathname`. The same release notes also state that `request.url.pathname` has not changed.

Refs: https://github.com/hapijs/hapi/issues/3871