### PR TITLE
Improve browser support

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "abstract-logging": "^1.0.0",
     "hoek": "^6.1.2",
-    "pino": "^5.10.1",
+    "pino": "^5.12.3",
     "pino-pretty": "^2.5.0"
   },
   "repository": {


### PR DESCRIPTION
## What?
This PR bumps pino to v5.12.3 to include browser fix from https://github.com/pinojs/pino/pull/612

## Why? 
It enables `hapi-pino` to be used within Hapi embedded in WebExtension context:  https://github.com/ipfs-shipyard/ipfs-companion/issues/664 https://github.com/ipfs-shipyard/ipfs-companion/issues/716