### PR TITLE
niche browser support case (cf https://github.com/pinojs/pino/pull/612)

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
 const Hoek = require('@hapi/hoek')
 const pino = require('pino')
 const { stdSerializers } = pino
-const { serializersSym } = pino.symbols
+const serializersSym = Symbol.for('pino.serializers')
 const nullLogger = require('abstract-logging')
 
 const levels = ['trace', 'debug', 'info', 'warn', 'error']


### PR DESCRIPTION
rather than exporting all symbols in pino browser which adds payload overhead and causes back compat issues  (https://github.com/pinojs/pino/pull/647 IE11 doesn't support Symbols - the alternative is more payload overhead for a polyfill) we can use `Symbol.for` instead in hapi-pino to support the case from https://github.com/pinojs/pino/pull/612
