### PR TITLE
Fix UnhandledPromiseRejection warning when logging on an ignored path

### DIFF
--- a/index.js
+++ b/index.js
@@ -145,6 +145,11 @@ async function register (server, options) {
   }
 
   function logEvent (current, event) {
+    // check for null logger
+    if (current === nullLogger) {
+      return
+    }
+
     var tags = event.tags
     var data = event.data
 


### PR DESCRIPTION
# Description
A few days ago I ran into a bug where logging via `request.log` would cause unhandled promise rejection warnings on routes with disabled logging. I traced it down to [this line](https://github.com/pinojs/hapi-pino/blob/master/index.js#L172). Basically on an ignored route, `current` is equal to the `nullLogger` which doesn't have a `levels` property. 

# Steps to reproduce
- Add a `request.log([level])` statement within a route handler such that `level` is a valid log level configured within hapi-pino such as 'info', 'warn', 'error', etc.
- Disable that route by adding it to `ignorePaths`
- Make a request to that route

I've added a unit test which reproduces this bug.