### PR TITLE
fixes #84

### DIFF
--- a/index.js
+++ b/index.js
@@ -117,7 +117,7 @@ async function register (server, options) {
     }
 
     const info = request.info
-    request.logger.info(
+    logger.info(
       {
         payload: options.logPayload ? request.payload : undefined,
         tags: options.logRouteTags ? request.route.settings.tags : undefined,


### PR DESCRIPTION
User `logger` of register scoped variable instead of `request.logger` seems to solve #84