### PR TITLE
feat: add options.getChildBindings()

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ events"](#hapievents) section.
   // with mergeHapiLogData: false (Default)
   { level: 30, data: { hello: 'world' }}
   ```
+- `[getChildBindings]` - Takes a function with the request as an input, and returns the object that will be passed into pinoLogger.child(). If omitted, then `{ req: request }` will be used for the child bindings, which automatically adds the request to every pino log call
 - `[ignorePaths]` - Takes an array of string routes and disables logging for each.  Useful for health checks or any route that does not need logging. E.g `['/health']`
 - `[level]` - Set the minumum level that Pino should log out. See [Level](https://github.com/pinojs/pino/blob/master/docs/api.md#level). For example, `{level: 'debug'}` would configure Pino to output all `debug` or higher events.
 - `[redact]` - Path to be redacted in the log lines. See the [log redaction](https://getpino.io/#/docs/redaction) docs for more details.

--- a/index.js
+++ b/index.js
@@ -67,6 +67,7 @@ async function register (server, options) {
   }
 
   const mergeHapiLogData = options.mergeHapiLogData
+  const getChildBindings = options.getChildBindings ? options.getChildBindings : (request) => ({ req: request })
 
   // expose logger as 'server.logger()'
   server.decorate('server', 'logger', () => logger)
@@ -78,7 +79,7 @@ async function register (server, options) {
       return h.continue
     }
 
-    const childBindings = options.getChildBindings ? options.getChildBindings(request) : { req: request }
+    const childBindings = getChildBindings(request)
     request.logger = logger.child(childBindings)
 
     return h.continue
@@ -99,7 +100,7 @@ async function register (server, options) {
       return
     }
 
-    const childBindings = options.getChildBindings ? options.getChildBindings(request) : { req: request }
+    const childBindings = getChildBindings(request)
     request.logger = request.logger || logger.child(childBindings)
 
     if (event.error && isEnabledLogEvent(options, 'request-error')) {

--- a/index.js
+++ b/index.js
@@ -77,7 +77,10 @@ async function register (server, options) {
       request.logger = nullLogger
       return h.continue
     }
-    request.logger = logger.child({ req: request })
+
+    const childBindings = options.getChildBindings ? options.getChildBindings(request) : { req: request }
+    request.logger = logger.child(childBindings)
+
     return h.continue
   })
 
@@ -96,7 +99,8 @@ async function register (server, options) {
       return
     }
 
-    request.logger = request.logger || logger.child({ req: request })
+    const childBindings = options.getChildBindings ? options.getChildBindings(request) : { req: request }
+    request.logger = request.logger || logger.child(childBindings)
 
     if (event.error && isEnabledLogEvent(options, 'request-error')) {
       request.logger.error(


### PR DESCRIPTION
Related suggestion issue: https://github.com/pinojs/hapi-pino/issues/86

This PR adds an optional `options.getChildBindings(request) => Pino.Bindings` function to the hapi-pino options object.

This allows you to customize the bindings being passed into `logger.child()`, which was previously hardcoded to always be `{ req: request }`

If omitted, it keeps the old behavior of `{ req: request }`

```javascript
    const plugin = {
      plugin: Pino,
      options: {
        stream: stream,
        level: 'info',
        getChildBindings: (req) => ({ custom: true })
      }
    }

    await server.register(plugin)
```
