### PR TITLE
options.getChildBindings remove default value to avoid duplicate req …

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,8 +188,6 @@ events"](#hapievents) section.
 
 ### `options.getChildBindings: (request) => { [key]: any }`
 
-  **Default**: `() => { req: Request }`, which automatically adds the request to every pino log call
-
   Takes a function with the request as an input, and returns the object that will be passed into pinoLogger.child().
 
 ### `options.ignorePaths: string[]`

--- a/index.js
+++ b/index.js
@@ -67,7 +67,6 @@ async function register (server, options) {
   }
 
   const mergeHapiLogData = options.mergeHapiLogData
-  const getChildBindings = options.getChildBindings ? options.getChildBindings : (request) => ({ req: request })
   const logRequestStart = options.logRequestStart
 
   // expose logger as 'server.logger()'
@@ -80,8 +79,13 @@ async function register (server, options) {
       return h.continue
     }
 
-    const childBindings = getChildBindings(request)
-    request.logger = logger.child(childBindings)
+    if (options.getChildBindings) {
+      const childBindings = options.getChildBindings(request)
+      request.logger = logger.child(childBindings)
+    }
+    else {
+      request.logger = logger
+    }
 
     if (logRequestStart) {
       request.logger.info({
@@ -107,8 +111,13 @@ async function register (server, options) {
       return
     }
 
-    const childBindings = getChildBindings(request)
-    request.logger = request.logger || logger.child(childBindings)
+    if (options.getChildBindings) {
+      const childBindings = options.getChildBindings(request)
+      request.logger = logger.child(childBindings)
+    }
+    else {
+      request.logger = request.logger || logger
+    }
 
     if (event.error && isEnabledLogEvent(options, 'request-error')) {
       request.logger.error(

--- a/test.js
+++ b/test.js
@@ -897,7 +897,7 @@ experiment('options.logRequestStart', () => {
         expect(data.res).to.be.undefined()
       } else {
         expect(data.msg).to.equal('request completed')
-        expect(data.req).to.be.an.object()
+        expect(data.req).to.be.undefined()
         expect(data.res).to.be.an.object()
         done()
       }
@@ -1286,7 +1286,7 @@ experiment('ignore request.log logs for paths in ignorePaths', () => {
       path: '/foo',
       method: 'GET',
       handler: (req, h) => {
-        req.log([level], 'foo')
+        req.log([level], 'foo from handler')
         return 'foo'
       }
     })
@@ -1295,10 +1295,10 @@ experiment('ignore request.log logs for paths in ignorePaths', () => {
     const done = new Promise((resolve, reject) => {
       resolver = resolve
     })
+
     const stream = sink(data => {
-      expect(data.req.url).to.endWith('/foo')
       expect(data.tags).to.equal([level])
-      expect(data.data).to.equal('foo')
+      expect(data.data).to.equal('foo from handler')
       resolver()
     })
     const logger = require('pino')(stream)


### PR DESCRIPTION
https://github.com/pinojs/hapi-pino/issues/91

Didn't update version. Also tests should be reviewed because in my opinion they don't do what they are meant to do.

```
//test 
experiment('ignore request.log logs for paths in ignorePaths', () => {
  test('when path matches entry in ignorePaths, nothing should be logged', async () => {

server.route({
      path: '/foo',
      method: 'GET',
      handler: (req, h) => {
        req.log([level], 'foo')
        return 'foo'
      }
})

//It didn't test against route, but 2 log entries are created. One with req.log and second is default route logging.

-expect(data.data).to.equal('foo')
+expect(data.data).to.equal('foo from handler')
```
