### PR TITLE
feat: ignored by tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,15 @@ events"](#hapievents) section.
   ignorePaths: ['/health']
   ```
 
+### `options.ignoreTags: string[]`
+  Takes an array of string tags and disables logging for each.  Useful for health checks or any route that does not need logging.
+
+  **Example**:  
+  Do not log for route with `healthcheck` tag
+  ```js
+  ignoreTags: ['healthcheck']
+  ```
+
 ### `options.level: Pino.Level`
   **Default**: `'info'`
 

--- a/index.js
+++ b/index.js
@@ -155,18 +155,24 @@ async function register (server, options) {
   })
 
   function isLoggingIgnored (options, request) {
-    return (
-      (
-        options.ignoreTags &&
-        options.ignoreTags.some(
-          (ignoreTag) => (
-            request.route.settings.tags &&
-            request.route.settings.tags.includes(ignoreTag)
-          )
-        )
-      ) ||
-      (options.ignorePaths && ignoreTable[request.url.pathname])
-    )
+    if (options.ignorePaths && ignoreTable[request.url.pathname]) {
+      return true
+    }
+
+    const ignoreTags = options.ignoreTags
+    const routeTags = request.route.settings.tags
+
+    if (!ignoreTags || !routeTags) {
+      return false
+    }
+
+    for (var index = ignoreTags.length; index >= 0; index--) {
+      if (routeTags.includes(ignoreTags[index])) {
+        return true
+      }
+    }
+
+    return false
   }
 
   function isEnabledLogEvent (options, name) {


### PR DESCRIPTION
Usually we wants to group multiple routes in tags, however ignoring these routes one by one seems to be a tedious process. It would make more sense to support such a case by just ignoring through the tags instead, hence this PR.