### PR TITLE
fix: use scoped logger if request.logger is not available

### DIFF
--- a/index.js
+++ b/index.js
@@ -107,8 +107,10 @@ async function register (server, options) {
       return
     }
 
-    const childBindings = getChildBindings(request)
-    request.logger = request.logger || logger.child(childBindings)
+    if (!request.logger) {
+      const childBindings = getChildBindings(request)
+      request.logger = logger.child(childBindings)
+    }
 
     if (event.error && isEnabledLogEvent(options, 'request-error')) {
       request.logger.error(
@@ -129,8 +131,11 @@ async function register (server, options) {
     }
 
     const info = request.info
-    const childBindings = getChildBindings(request)
-    request.logger = request.logger || logger.child(childBindings)
+
+    if (!request.logger) {
+      const childBindings = getChildBindings(request)
+      request.logger = logger.child(childBindings)
+    }
 
     request.logger.info(
       {

--- a/index.js
+++ b/index.js
@@ -129,6 +129,9 @@ async function register (server, options) {
     }
 
     const info = request.info
+    const childBindings = getChildBindings(request)
+    request.logger = request.logger || logger.child(childBindings)
+
     request.logger.info(
       {
         payload: options.logPayload ? request.payload : undefined,

--- a/test.js
+++ b/test.js
@@ -356,6 +356,34 @@ experiment('logs each request', () => {
 
     expect(options).to.equal(optionsClone)
   })
+
+  test('handles removed request.logger', async () => {
+    const server = getServer()
+
+    let done
+
+    const finish = new Promise(function (resolve, reject) {
+      done = resolve
+    })
+
+    server.route({
+      path: '/',
+      method: 'GET',
+      handler: async (req, h) => {
+        req.logger = undefined
+        return 'hello world'
+      }
+    })
+
+    await registerWithSink(server, 'info', data => {
+      expect(data.res.statusCode).to.equal(200)
+      expect(data.msg).to.equal('request completed')
+      done()
+    })
+
+    await server.inject('/')
+    await finish
+  })
 })
 
 experiment('logs through server.log', () => {


### PR DESCRIPTION
Fixes #84 