### PR TITLE
refactor: server.logger() function removed in favor of server.logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ async function start () {
   })
 
   // also as a decorated API
-  server.logger().info('another way for accessing it')
+  server.logger.info('another way for accessing it')
 
   // and through Hapi standard logging system
   server.log(['subsystem'], 'third way for accessing it')
@@ -242,7 +242,7 @@ events"](#hapievents) section.
 <a name="serverdecorations"></a>
 ### Server Decorations
 
-**hapi-pino** decorates the Hapi server with `server.logger()`, which is a function that returns the current instance of
+**hapi-pino** decorates the Hapi server with `server.logger`, which is an instance of
   [pino][pino]. See its doc for the way to actual log.
 
 <a name="requestdecorations"></a>

--- a/index.js
+++ b/index.js
@@ -79,8 +79,8 @@ async function register (server, options) {
       ? () => !!options.logRequestComplete
       : () => true
 
-  // expose logger as 'server.logger()'
-  server.decorate('server', 'logger', () => logger)
+  // expose logger as 'server.logger'
+  server.decorate('server', 'logger', logger)
 
   // set a logger for each request
   server.ext('onRequest', (request, h) => {

--- a/test.js
+++ b/test.js
@@ -101,11 +101,11 @@ test('server.app.logger is undefined', async () => {
   expect(server.app.logger).to.be.undefined()
 })
 
-experiment('logs through the server.logger()', () => {
+experiment('logs through the server.logger', () => {
   ltest(async level => {
     const server = getServer()
     await registerWithSink(server, level, onHelloWorld)
-    server.logger()[level]('hello world')
+    server.logger[level]('hello world')
   })
 })
 
@@ -799,7 +799,7 @@ experiment('uses a prior pino instance', () => {
     }
 
     await server.register(plugin)
-    server.logger().info({ foo: 'bar' }, 'hello world')
+    server.logger.info({ foo: 'bar' }, 'hello world')
     await finish
   })
 })


### PR DESCRIPTION
BREAKING CHANGE: Instead of calling `server.logger()` to get the logger instance of the server it can now be destructured directly `server.logger`

Closes #98 