### PR TITLE
Support custom success message

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,10 @@ events"](#hapievents) section.
 
   Path to be redacted in the log lines. See the [log redaction](https://getpino.io/#/docs/redaction) docs for more details.
 
+### `options.customSuccessMessage: string`
+
+  Override the default "request completed" message logged when a request completes.
+
 <a name="serverdecorations"></a>
 ### Server Decorations
 

--- a/index.js
+++ b/index.js
@@ -168,7 +168,7 @@ async function register (server, options) {
           res: request.raw.res,
           responseTime: (info.completed !== undefined ? info.completed : info.responded) - info.received
         },
-        'request completed'
+        options.customSuccessMessage || 'request completed'
       )
     }
   })


### PR DESCRIPTION
This is to support customizing the success message when the request completes.

I would gladly add tests but the test suite is failing for me after a fresh install and on master with: 

```
Failed tests:

  10) logs each request track responseTime when server closes connection prematurely:

      Cannot read property 'statusCode' of null

```