### PR TITLE
Support custom keys for the request and response

### DIFF
--- a/index.js
+++ b/index.js
@@ -76,7 +76,11 @@ async function register (server, options) {
   }
 
   const mergeHapiLogData = options.mergeHapiLogData
-  const getChildBindings = options.getChildBindings ? options.getChildBindings : (request) => ({ req: request })
+  const customAttributeKeys = options.customAttributeKeys || {} 
+  const reqKey = customAttributeKeys.req || 'req'
+  const resKey = customAttributeKeys.res || 'res'
+
+  const getChildBindings = options.getChildBindings ? options.getChildBindings : (request) => ({ [reqKey]: request })
   const shouldLogRequestStart = typeof options.logRequestStart === 'function'
     ? (request) => options.logRequestStart(request)
     : typeof options.logRequestStart === 'boolean'
@@ -103,7 +107,7 @@ async function register (server, options) {
 
     if (shouldLogRequestStart(request)) {
       request.logger.info({
-        req: request
+        [reqKey]: request
       }, 'request start')
     }
 
@@ -164,8 +168,8 @@ async function register (server, options) {
           tags: options.logRouteTags ? request.route.settings.tags : undefined,
           // note: pino doesnt support unsetting a key, so this next line
           // has the effect of setting it or "leaving it as it was" if it was already added via child bindings
-          req: shouldLogRequestStart(request) ? undefined : request,
-          res: request.raw.res,
+          [reqKey]: shouldLogRequestStart(request) ? undefined : request,
+          [resKey]: request.raw.res,
           responseTime: (info.completed !== undefined ? info.completed : info.responded) - info.received
         },
         'request completed'

--- a/index.js
+++ b/index.js
@@ -76,7 +76,7 @@ async function register (server, options) {
   }
 
   const mergeHapiLogData = options.mergeHapiLogData
-  const customAttributeKeys = options.customAttributeKeys || {} 
+  const customAttributeKeys = options.customAttributeKeys || {}
   const reqKey = customAttributeKeys.req || 'req'
   const resKey = customAttributeKeys.res || 'res'
 


### PR DESCRIPTION
I took this idea from `pino-http`, where it's allow to set a custom place for the `req` and `res`, both for the logged objects and the child logger.

I would gladly add tests but the test suite is currently failing for me after a fresh install and on master with:

```
Failed tests:

  10) logs each request track responseTime when server closes connection prematurely:

      Cannot read property 'statusCode' of null

```