### PR TITLE
Allow tags to point to a custom level defined in pino's customLevels

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,13 +6,13 @@ const { stdSerializers } = pino
 const serializersSym = Symbol.for('pino.serializers')
 const nullLogger = require('abstract-logging')
 
-const levels = ['trace', 'debug', 'info', 'warn', 'error']
 const levelTags = {
   trace: 'trace',
   debug: 'debug',
   info: 'info',
   warn: 'warn',
-  error: 'error'
+  error: 'error',
+  fatal: 'fatal'
 }
 
 let ignoredEventTags = {
@@ -51,6 +51,7 @@ async function register (server, options) {
     logger = pino(options, stream)
   }
 
+  const levels = Object.keys(logger.levels.values)
   const tagToLevels = Object.assign({}, levelTags, options.tags)
   const allTags = options.allTags || 'info'
 

--- a/test.js
+++ b/test.js
@@ -519,6 +519,34 @@ experiment('logs through server.log', () => {
     server.log(['something'], 'hello world')
     await finish
   })
+
+  test('allow tags to point to a custom level defined in pino\'s customLevels', async () => {
+    const server = getServer()
+    let done
+    const finish = new Promise(function (resolve, reject) {
+      done = resolve
+    })
+    const stream = sink(data => {
+      expect(data.level).to.equal(123)
+      done()
+    })
+    const plugin = {
+      plugin: Pino,
+      options: {
+        stream: stream,
+        customLevels: {
+          bar: 123
+        },
+        tags: {
+          foo: 'bar'
+        }
+      }
+    }
+    await server.register(plugin)
+
+    server.log(['foo'], 'hello world')
+    await finish
+  })
 })
 
 experiment('logs through request.log', () => {


### PR DESCRIPTION
You can define `customLevels` with pino, e.g. 

```js
customLevels: {
  bar: 123
}
```

Meaning when logging with `logger.bar('hello world')` it results in `{ level: 123, ... }`.

`hapi-pino` accepts an option of `tags`, which is a map of hapi log tags to pino's level. However, the library has a hardcoded list of levels:

```js
const levels = ['trace', 'debug', 'info', 'warn', 'error']
```

It means you cannot define `tags` which would point to a custom level defined via `customLevels`:

```js
options: {
    customLevels: {
        bar: 123
    },
    tags: {
        foo: 'bar',
    }
}
```

Above throws an error `invalid tag levels` because it checks level `bar` against `['trace', 'debug', 'info', 'warn', 'error']`.

This PR compares `bar` against `Object.keys(logger.levels.values)`, which is the valid array of levels that pino accepts, including those defined via `customLevels`.

PR also adds a missing `fatal` level to `levelTags` object, fixing `server.log('fatal', 'bye world');` resulting in `level: 30`/`info`.
