### PR TITLE
Fix test case for simulating a closed connection

### DIFF
--- a/test.js
+++ b/test.js
@@ -203,6 +203,15 @@ experiment('logs each request', () => {
       done = resolve
     })
 
+    server.route({
+      path: '/',
+      method: 'GET',
+      handler: async (req, h) => {
+        await sleep(10)
+        return 'hello world'
+      }
+    })
+
     await registerWithSink(server, 'info', data => {
       expect(data.res.statusCode).to.equal(200)
       expect(data.msg).to.equal('request completed')
@@ -214,7 +223,7 @@ experiment('logs each request', () => {
 
     server.inject({
       url: '/',
-      method: 'POST',
+      method: 'GET',
       simulate: {
         close: true
       }


### PR DESCRIPTION
This is a proposal to fix the test that's currently blocking #123, #124 and #125. 

Tbh I'm not 100% sure if it's the right fix - for some reason, simulating a connection close seems to make hapi fail internally for POST requests, it has nothing to do with this test (the functionality seems to work fine AFAICT). For some reason, it works with GET requests though. 

I'm adding a separate route with an artificial delay instead of just hitting `GET /something`, as otherwise the assertion on the response time being greater than 0 is flaky, as it sometimes _is_ 0, depending on how quick the test runs.