### PR TITLE
Add type declarations

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,61 @@
+// Type definitions for hapi-pino 8.0
+// Project: https://github.com/pinojs/hapi-pino#readme
+// Definitions by: Rodrigo Saboya <https://github.com/saboya>
+//                 Todd Bealmear <https://github.com/todd>
+//                 Matt Jeanes <https://github.com/BlooJeans>
+//                 Kyle Gray <https://github.com/GoPro16>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// TypeScript Version: 2.8
+
+/// <reference types='node' />
+
+import type { pino } from 'pino';
+
+import { Plugin, Request } from '@hapi/hapi';
+
+declare module '@hapi/hapi' {
+  interface Server {
+    logger: pino.Logger;
+  }
+
+  interface Request {
+    logger: pino.Logger;
+  }
+}
+
+declare namespace HapiPino {
+  interface Serializers {
+    [key: string]: pino.SerializerFn;
+  }
+
+  interface Options {
+    timestamp?: boolean | (() => string) | undefined;
+    logQueryParams?: boolean | undefined;
+    logPayload?: boolean | undefined;
+    logRouteTags?: boolean | undefined;
+    logRequestStart?: boolean | ((req: Request) => boolean) | undefined;
+    logRequestComplete?: boolean | ((req: Request) => boolean) | undefined;
+    stream?: NodeJS.WriteStream | undefined;
+    prettyPrint?: boolean | pino.PrettyOptions | undefined;
+    tags?: { [key in pino.Level]?: string } | undefined;
+    allTags?: pino.Level | undefined;
+    serializers?: Serializers | undefined;
+    getChildBindings?:
+      | ((req: Request) => {
+          level?: pino.Level | string | undefined;
+          serializers?: Serializers | undefined;
+          [key: string]: any;
+        })
+      | undefined;
+    instance?: pino.Logger | undefined;
+    logEvents?: string[] | false | null | undefined;
+    mergeHapiLogData?: boolean | undefined;
+    ignorePaths?: string[] | undefined;
+    level?: pino.Level | undefined;
+    redact?: string[] | pino.redactOptions | undefined;
+  }
+}
+
+declare var HapiPino: Plugin<HapiPino.Options>;
+
+export = HapiPino;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for hapi-pino 8.0
+// Type definitions for hapi-pino 9.0
 // Project: https://github.com/pinojs/hapi-pino#readme
 // Definitions by: Rodrigo Saboya <https://github.com/saboya>
 //                 Todd Bealmear <https://github.com/todd>

--- a/index.d.ts
+++ b/index.d.ts
@@ -51,6 +51,9 @@ declare namespace HapiPino {
     ignorePaths?: string[] | undefined;
     level?: pino.Level | undefined;
     redact?: string[] | pino.redactOptions | undefined;
+    ignoreTags?: string[] | undefined;
+    ignoreFunc?: ((options: Options, request: Request) => boolean) | undefined;
+    ignoredEventTags?: object[] | undefined;
   }
 }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -11,6 +11,16 @@ import type { pino } from 'pino';
 
 import { Plugin, Request } from '@hapi/hapi';
 
+declare module '@hapi/hapi' {
+  interface Server {
+    logger: pino.Logger;
+  }
+
+  interface Request {
+    logger: pino.Logger;
+  }
+}
+
 declare namespace HapiPino {
   interface Serializers {
     [key: string]: pino.SerializerFn;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,10 +1,8 @@
 // Type definitions for hapi-pino 9.0
-// Project: https://github.com/pinojs/hapi-pino#readme
 // Definitions by: Rodrigo Saboya <https://github.com/saboya>
 //                 Todd Bealmear <https://github.com/todd>
 //                 Matt Jeanes <https://github.com/BlooJeans>
 //                 Kyle Gray <https://github.com/GoPro16>
-// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
 // TypeScript Version: 2.8
 
 /// <reference types='node' />

--- a/index.d.ts
+++ b/index.d.ts
@@ -11,16 +11,6 @@ import type { pino } from 'pino';
 
 import { Plugin, Request } from '@hapi/hapi';
 
-declare module '@hapi/hapi' {
-  interface Server {
-    logger: pino.Logger;
-  }
-
-  interface Request {
-    logger: pino.Logger;
-  }
-}
-
 declare namespace HapiPino {
   interface Serializers {
     [key: string]: pino.SerializerFn;

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,0 +1,45 @@
+import { Request, Server } from '@hapi/hapi';
+import pino from 'pino';
+import * as HapiPino from '.';
+import { expectType } from 'tsd';
+
+const pinoLogger = pino();
+
+const server = new Server();
+
+const options: HapiPino.Options = {
+  timestamp: () => `,"time":"${new Date(Date.now()).toISOString()}"`,
+  logQueryParams: false,
+  logPayload: false,
+  logRouteTags: false,
+  logRequestStart: false,
+  logRequestComplete: true,
+  stream: process.stdout,
+  prettyPrint: process.env.NODE_ENV !== 'PRODUCTION',
+  tags: {
+    trace: 'trace',
+    debug: 'debug',
+    info: 'info',
+    warn: 'warn',
+    error: 'error',
+    fatal: 'fatal',
+  },
+  allTags: 'info',
+  serializers: {
+    req: (req: any) => console.log(req),
+  },
+  getChildBindings: (req: Request) => ({
+    'x-request-id': req.headers['x-request-id'],
+  }),
+  instance: pinoLogger,
+  logEvents: false,
+  mergeHapiLogData: false,
+  ignorePaths: ['/testRoute'],
+  level: 'debug',
+  redact: ['test.property'],
+  ignoreTags: ['healthcheck'],
+  ignoreFunc: (options, request) => request.path.startsWith('/static'),
+  ignoredEventTags: [{ log: ['DEBUG', 'TEST'], request: ['DEBUG', 'TEST'] }],
+};
+
+expectType<Promise<void>>(server.register({ plugin: HapiPino, options }));

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "coverage": "lab test.js -c",
     "coverage:lcov": "lab test.js -r lcov -o coverage/lcov.info",
     "coveralls": "lab test.js -r lcov | coveralls",
-    "test": "standard && lab --timeout 100000 test.js"
+    "test": "standard && lab --timeout 100000 test.js",
+    "test-types": "tsd"
   },
   "keywords": [
     "hapi",
@@ -28,10 +29,12 @@
     "make-promises-safe": "^5.1.0",
     "pre-commit": "^1.2.2",
     "split2": "^3.1.1",
-    "standard": "^14.3.3"
+    "standard": "^14.3.3",
+    "tsd": "^0.18.0"
   },
   "dependencies": {
     "@hapi/hoek": "^9.0.0",
+    "@types/hapi__hapi": "^20.0.9",
     "abstract-logging": "^2.0.0",
     "get-caller-file": "^2.0.5",
     "pino": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "9.0.0",
   "description": "Hapi plugin for the Pino logger ",
   "main": "index.js",
+  "types": "index.d.ts",
   "scripts": {
     "coverage": "lab test.js -c",
     "coverage:lcov": "lab test.js -r lcov -o coverage/lcov.info",

--- a/package.json
+++ b/package.json
@@ -8,8 +8,7 @@
     "coverage": "lab test.js -c",
     "coverage:lcov": "lab test.js -r lcov -o coverage/lcov.info",
     "coveralls": "lab test.js -r lcov | coveralls",
-    "test": "standard && lab --timeout 100000 test.js",
-    "test-types": "tsd"
+    "test": "standard && lab --timeout 100000 test.js && tsd"
   },
   "keywords": [
     "hapi",


### PR DESCRIPTION
@types/hapi-pino is not compatible with pino's type declarations: [https://github.com/pinojs/pino/blob/38ff645e7fd1a62ccffaa710070a03ba71495f1e/pino.d.ts](url)

The goal of this PR is to make @types/hapi-pino unnecessary.