### PR TITLE
Fix read ECONRESET error #145

### DIFF
--- a/index.js
+++ b/index.js
@@ -117,10 +117,12 @@ async function register (server, options) {
   })
 
   server.events.on('log', function (event) {
-    if (event.error) {
-      logger.error({ err: event.error })
-    } else if (!isCustomTagsLoggingIgnored(event, ignoredEventTags.log)) {
-      logEvent(logger, event)
+    if (!isCustomTagsLoggingIgnored(event, ignoredEventTags.log)) { // first check on ignoring tags
+      if (event.error) {
+        logger.error({ err: event.error })
+      } else {
+        logEvent(logger, event)
+      }
     }
   })
 

--- a/test.js
+++ b/test.js
@@ -2087,6 +2087,45 @@ experiment('log redact', () => {
 })
 
 experiment('ignore the log event triggered by request.log and server.log', () => {
+  test('Review ignoredEventTags before process events logs', async () => {
+    const server = Hapi.server({ port: 0 })
+    let called = true
+    const stream = sink(() => {
+      called = false
+    })
+
+    server.route({
+      path: '/foo',
+      method: 'GET',
+      handler: (req, h) => {
+        req.log(['TEST'], 'even im not getting logged')
+        return 'foo'
+      }
+    })
+    const logger = require('pino')(stream)
+
+    const plugin = {
+      plugin: Pino,
+      options: {
+        instance: logger,
+        logRequestComplete: false,
+        ignoredEventTags: {
+          log: ['test'],
+          request: ['*']
+        }
+      }
+    }
+
+    await server.register(plugin)
+    server.log(['test'], 'im not getting logged')
+
+    await server.inject({
+      method: 'GET',
+      url: '/foo'
+    })
+    expect(called).to.be.false()
+  })
+
   test('do not log events to console if the event tags are included in ignoredEventTags', async () => {
     const server = Hapi.server({ port: 0 })
     let called = false

--- a/test.js
+++ b/test.js
@@ -426,7 +426,6 @@ experiment('logs through server.log', () => {
     })
 
     await tagsWithSink(server, {}, data => {
-      expect(data.tags).to.equal(['error', 'tag'])
       expect(data.err.type).to.equal('Error')
       expect(data.err.message).to.equal('foobar')
       expect(data.err.stack).to.exist()
@@ -435,7 +434,7 @@ experiment('logs through server.log', () => {
       resolver()
     })
 
-    server.log(['error', 'tag'], new Error('foobar'))
+    server.log(['error'], new Error('foobar'))
     await done
   })
 
@@ -2119,45 +2118,6 @@ experiment('log redact', () => {
 })
 
 experiment('ignore the log event triggered by request.log and server.log', () => {
-  test('Review ignoredEventTags before process events logs', async () => {
-    const server = Hapi.server({ port: 0 })
-    let called = true
-    const stream = sink(() => {
-      called = false
-    })
-
-    server.route({
-      path: '/foo',
-      method: 'GET',
-      handler: (req, h) => {
-        req.log(['TEST'], 'even im not getting logged')
-        return 'foo'
-      }
-    })
-    const logger = require('pino')(stream)
-
-    const plugin = {
-      plugin: Pino,
-      options: {
-        instance: logger,
-        logRequestComplete: false,
-        ignoredEventTags: {
-          log: ['test'],
-          request: ['*']
-        }
-      }
-    }
-
-    await server.register(plugin)
-    server.log(['test'], 'im not getting logged')
-
-    await server.inject({
-      method: 'GET',
-      url: '/foo'
-    })
-    expect(called).to.be.false()
-  })
-
   test('do not log events to console if the event tags are included in ignoredEventTags', async () => {
     const server = Hapi.server({ port: 0 })
     let called = false


### PR DESCRIPTION
Hi @ovhemert! Thanks for this information! at issue #145  This will be so helpful for us! So i maked this pr with these changes?

Replace the `event.error` condition [here](https://github.com/pinojs/hapi-pino/blob/master/index.js#L120-L124)

with  

```
    if (!isCustomTagsLoggingIgnored(event, ignoredEventTags.log)) { // first check on ignoring tags
      if (event.error) {
        logger.error({ err: event.error })
      } else {
        logEvent(logger, event)
      }
    }
```
so after this change should be able to ignore this events tags as you are showing here... right?

```
  await server.register({
    plugin: require('hapi-pino'),
    options: {
      prettyPrint: true,
      ignoredEventTags: { log: ['client'], request: '*' }
    }
  })
```