### PR TITLE
Include tags for errors logged with server.log() or request.log()

### DIFF
--- a/index.js
+++ b/index.js
@@ -118,7 +118,7 @@ async function register (server, options) {
 
   server.events.on('log', function (event) {
     if (event.error) {
-      logger.error({ err: event.error })
+      logger.error({ tags: event.tags, err: event.error })
     } else if (!isCustomTagsLoggingIgnored(event, ignoredEventTags.log)) {
       logEvent(logger, event)
     }
@@ -142,6 +142,7 @@ async function register (server, options) {
     if (event.error && isEnabledLogEvent(options, 'request-error')) {
       request.logger.error(
         {
+          tags: event.tags,
           err: event.error
         },
         'request error'

--- a/test.js
+++ b/test.js
@@ -426,6 +426,7 @@ experiment('logs through server.log', () => {
     })
 
     await tagsWithSink(server, {}, data => {
+      expect(data.tags).to.equal(['error', 'tag'])
       expect(data.err.type).to.equal('Error')
       expect(data.err.message).to.equal('foobar')
       expect(data.err.stack).to.exist()
@@ -434,7 +435,7 @@ experiment('logs through server.log', () => {
       resolver()
     })
 
-    server.log(['error'], new Error('foobar'))
+    server.log(['error', 'tag'], new Error('foobar'))
     await done
   })
 
@@ -588,6 +589,37 @@ experiment('logs through request.log', () => {
         cb()
       }
     )
+
+    await server.inject('/')
+    await done
+  })
+
+  test('with logged error object', async () => {
+    const server = getServer()
+    server.route({
+      path: '/',
+      method: 'GET',
+      handler: (req, h) => {
+        req.log(['error', 'tag'], new Error('foobar'))
+        return 'hello world'
+      }
+    })
+
+    let resolver
+    const done = new Promise((resolve, reject) => {
+      resolver = resolve
+    })
+
+    await tagsWithSink(server, {}, (data) => {
+      expect(data.tags).to.equal(['error', 'tag'])
+      expect(data.err.type).to.equal('Error')
+      expect(data.err.message).to.equal('foobar')
+      expect(data.err.stack).to.exist()
+      // highest level tag
+      expect(data.level).to.equal(50)
+
+      resolver()
+    })
 
     await server.inject('/')
     await done


### PR DESCRIPTION
When `request.log()` or `server.log()` is used to log an error object, the event tags are now included as part of the log.

Solves #150 