### PR TITLE
fix: allow logging numbers when mergeHapiLogData is true

### DIFF
--- a/index.js
+++ b/index.js
@@ -252,7 +252,7 @@ async function register (server, options) {
 
     var logObject
     if (mergeHapiLogData) {
-      if (typeof data === 'string') {
+      if (typeof data === 'string' || typeof data === 'number') {
         data = { [messageKey]: data }
       }
 

--- a/test.js
+++ b/test.js
@@ -1336,6 +1336,30 @@ experiment('logging with mergeHapiLogData option enabled', () => {
     await finish
   })
 
+  test('when data is a number, merge it as msg property', async () => {
+    const server = getServer()
+    let done
+    const finish = new Promise(function (resolve, reject) {
+      done = resolve
+    })
+    const stream = sink(data => {
+      expect(data).to.include({ msg: 1 })
+      done()
+    })
+    const plugin = {
+      plugin: Pino,
+      options: {
+        stream: stream,
+        level: 'info',
+        mergeHapiLogData: true
+      }
+    }
+
+    await server.register(plugin)
+    server.log(['info'], 1)
+    await finish
+  })
+
   test('respects `messageKey` option', async () => {
     const server = getServer()
     let done


### PR DESCRIPTION
The number/data from the log was being erased by the `Object.assign`.