### PR TITLE
Add support for custom messages on request completion/receive/failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,12 @@ events"](#hapievents) section.
   two via requestId (frequently done via `headers['x-request-id']`) , where "request start" only logs the request and a requestId,
   and `request completed` only logs the response and the requestId.
 
+### `options.customRequestStartMessage`
+
+  **Default**: 'request start'
+
+  Set to a `function (request) => { /* returns message string */ }`. This function will be invoked at each request received, setting "msg" property to returned string. If not set, default value will be used.
+
 ### `options.logRequestComplete: boolean | (Request) => Boolean`
 
   **Default**: true
@@ -127,6 +133,18 @@ events"](#hapievents) section.
   Whether hapi-pino should add a `log.info()` at the completion of Hapi requests for the given Request.
 
   For convenience, you can pass in `true` to always log `request complete` events, or `false` to disable logging `request complete` events
+
+### `options.customRequestCompleteMessage`
+
+  **Default**: '[response] ${request.method} ${request.path} ${request.raw.res.statusCode} (${responseTime}ms)'
+
+  Set to a `function (request, responseTime) => { /* returns message string */ }`. This function will be invoked at each completed request, setting "msg" property to returned string. If not set, default value will be used.
+
+### `options.customRequestErrorMessage`
+
+  **Default**: `error.message`
+
+  Set to a `function (request, err) => { /* returns message string */ }`. This function will be invoked at each failed request, setting "msg" property to returned string. If not set, default value will be used.
 
 ### `options.stream` Pino.DestinationStream
 


### PR DESCRIPTION
hapi-pino [9.2.0](https://github.com/pinojs/hapi-pino/releases/tag/v9.2.0) and [9.3.0](https://github.com/pinojs/hapi-pino/releases/tag/v9.3.0) added a few changes to the default output of "[request completed](https://github.com/pinojs/hapi-pino/pull/156)" and "[request error](https://github.com/pinojs/hapi-pino/pull/159)", that while useful for certain transports it can be redundant for others (the same information is already included). This pull request adds a way to customize these messages without changing the defaults:

- `customRequestStartMessage` - to customize messages when enabled by `logRequestStart`
- `customRequestCompleteMessage` - to customize messages when enabled by `logRequestComplete`
- `customRequestErrorMessage` - to customize request error messages

These properties are based on equivalent properties existing in other implementations, specifically in `pino-http`, but the terminology is changed to fit better with existing terminology in this project.

This also addresses #162 without unnecessarily changing the existing defaults.