### PR TITLE
Add optional support to log path params

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,12 @@ events"](#hapievents) section.
 
   When enabled, add the request query as `queryParams` to the `response` event log.
 
+### `options.logPathParams: boolean`
+
+  **Default**: `false`
+
+  When enabled, add the request params as `pathParams` to the `response` event log.
+
 ### `options.logRouteTags: boolean`
 
   **Default**: `false`

--- a/index.d.ts
+++ b/index.d.ts
@@ -18,6 +18,7 @@ declare namespace HapiPino {
   interface Options extends pino.LoggerOptions {
     timestamp?: boolean | (() => string) | undefined;
     logQueryParams?: boolean | undefined;
+    logPathParams?: boolean | undefined;
     logPayload?: boolean | undefined;
     logRouteTags?: boolean | undefined;
     logRequestStart?: boolean | ((req: Request) => boolean) | undefined;

--- a/index.js
+++ b/index.js
@@ -177,6 +177,7 @@ async function register (server, options) {
         {
           payload: options.logPayload ? request.payload : undefined,
           queryParams: options.logQueryParams ? request.query : undefined,
+          pathParams: options.logPathParams ? request.params : undefined,
           tags: options.logRouteTags ? request.route.settings.tags : undefined,
           res: request.raw.res,
           responseTime

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -10,6 +10,7 @@ const server = new Server();
 const options: HapiPino.Options = {
   timestamp: () => `,"time":"${new Date(Date.now()).toISOString()}"`,
   logQueryParams: false,
+  logPathParams: false,
   logPayload: false,
   logRouteTags: false,
   logRequestStart: false,

--- a/test.js
+++ b/test.js
@@ -2411,7 +2411,7 @@ experiment('logging with request queryParams', () => {
   })
 })
 
-experiment('logginw with request pathParams', () => {
+experiment('logging with request pathParams', () => {
   test('with pre-defined req serializer', async () => {
     const server = getServer()
     let resolver


### PR DESCRIPTION
hapi-pino binds the request only once during the `onRequest` hook:

https://github.com/pinojs/hapi-pino/blob/27806507920fda5db27c2daca0a99259423ba647/index.js#L111-L118

However, hapi only makes `request.params` available later in the [request lifecycle](https://hapi.dev/api/?v=20.2.2#request-lifecycle), and it is accessible only after `onPreAuth` at the earliest. This pull request adds optional support to log `pathParams` when `logPathParams` is `true`, in pretty much the same way that `logQueryParams` works