### PR TITLE
Add support to replace default serialalizers unwrapped

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,29 @@ events"](#hapievents) section.
   }
   ```
 
+### `options.wrapSerializers: boolean`
+
+  **Default**: `true`
+
+  When `false`, custom serializers will be passed the raw value directly.
+
+  **Example**:
+  If you prefer to work with the raw value directly, or you want to honor the custom serializers already defined by `options.instance`, you can pass in `options.wrapSerializers` as `false`:
+
+  ```js
+  {
+    wrapSerializers: false,
+    serializers: {
+      req (req) {
+        // `req` is the raw hapi's `Request` object, not the already serialized request from `pino.stdSerializers.req`.
+        return {
+          message: req.foo
+        };
+      }
+    }
+  }
+  ```
+
 ### `options.instance: Pino`
 
   Uses a previously created Pino instance as the logger.

--- a/index.d.ts
+++ b/index.d.ts
@@ -28,6 +28,7 @@ declare namespace HapiPino {
     allTags?: pino.Level | undefined;
     instance?: pino.Logger | undefined;
     logEvents?: string[] | false | null | undefined;
+    wrapSerializers: boolean | undefined;
     mergeHapiLogData?: boolean | undefined;
     ignorePaths?: string[] | undefined;
     ignoreTags?: string[] | undefined;

--- a/index.js
+++ b/index.js
@@ -29,9 +29,14 @@ async function register (server, options) {
   })
 
   options.serializers = options.serializers || {}
-  options.serializers.req = stdSerializers.wrapRequestSerializer(options.serializers.req || stdSerializers.req)
-  options.serializers.res = stdSerializers.wrapResponseSerializer(options.serializers.res || stdSerializers.res)
+
+  const wrapSerializers = 'wrapSerializers' in options ? options.wrapSerializers : true
+  const reqSerializer = options.serializers.req || stdSerializers.req
+  const resSerializer = options.serializers.res || stdSerializers.res
+
   options.serializers.err = options.serializers.err || pino.stdSerializers.err
+  options.serializers.req = wrapSerializers ? stdSerializers.wrapRequestSerializer(reqSerializer) : reqSerializer
+  options.serializers.res = wrapSerializers ? stdSerializers.wrapResponseSerializer(resSerializer) : resSerializer
 
   if (options.logEvents === undefined) {
     options.logEvents = ['onPostStart', 'onPostStop', 'response', 'request-error']

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -26,6 +26,7 @@ const options: HapiPino.Options = {
     fatal: 'fatal',
   },
   allTags: 'info',
+  wrapSerializers: false,
   serializers: {
     req: (req: any) => console.log(req),
   },


### PR DESCRIPTION
Presently is not really possible to completely replace hapi-pino's default serializers with a custom implementation as `req` and `res` serializers are always wrapped with the standard serializers. This pull request adds support to replace them unwrapped by providing the `wrapSerializers` option set to `false`