### PR TITLE
Make wrapSerializers optional

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -31,7 +31,7 @@ declare namespace HapiPino {
     allTags?: pino.Level | undefined;
     instance?: pino.Logger | undefined;
     logEvents?: string[] | false | null | undefined;
-    wrapSerializers: boolean | undefined;
+    wrapSerializers?: boolean | undefined;
     mergeHapiLogData?: boolean | undefined;
     ignorePaths?: string[] | undefined;
     ignoreTags?: string[] | undefined;


### PR DESCRIPTION
I think this should have been added as an optional property.