### PR TITLE
Remove prettyPrint from documentation and typedefs

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,14 +158,6 @@ events"](#hapievents) section.
 
   the binary stream to write stuff to
 
-### `options.prettyPrint: boolean`
-
-  **Default**: `false`
-
-  > This option is now deprecated, you should use the `transport` option. You can [view how to use it here](https://github.com/pinojs/pino-pretty#programmatic-integration). This will also allow you full customisation over `pino-pretty`
-
-  Pretty print the logs (same as `node server | pino`), disabled in production.  Enable in development by passing `true`
-
 ### `options.tags: ({ [key in pino.Level]?: string })`
 
   **Default**: exposed via `hapi-pino.levelTags`

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -16,7 +16,6 @@ const options: HapiPino.Options = {
   logRequestStart: false,
   logRequestComplete: true,
   stream: process.stdout,
-  prettyPrint: process.env.NODE_ENV !== 'PRODUCTION',
   tags: {
     trace: 'trace',
     debug: 'debug',


### PR DESCRIPTION
No longer a valid option since pino 8.x.