### PR TITLE
add option to log 4xx error details in request logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,12 @@ events"](#hapievents) section.
 
   When enabled, add the request route tags (as configured in hapi `route.options.tags`) `tags` to the `response` event log.
 
+### `options.log4xxResponseErrors: boolean`
+
+  **Default**: `false`
+
+  When enabled, responses with status codes in the 400-500 range will have the value returned by the hapi lifecycle method added to the `response` event log as `err`.
+
 ### `options.logRequestStart: boolean | (Request) => boolean`
 
   **Default**: false

--- a/index.d.ts
+++ b/index.d.ts
@@ -21,6 +21,7 @@ declare namespace HapiPino {
     logPathParams?: boolean | undefined;
     logPayload?: boolean | undefined;
     logRouteTags?: boolean | undefined;
+    log4xxResponseErrors?: boolean | undefined;
     logRequestStart?: boolean | ((req: Request) => boolean) | undefined;
     logRequestComplete?: boolean | ((req: Request) => boolean) | undefined;
     customRequestStartMessage?: ((req: Request) => string) | undefined;

--- a/index.js
+++ b/index.js
@@ -171,6 +171,7 @@ async function register (server, options) {
 
     if (shouldLogRequestComplete(request)) {
       const info = request.info
+      const statusCode = request.response.statusCode
       if (!request.logger) {
         const childBindings = getChildBindings(request)
         request.logger = logger.child(childBindings)
@@ -184,6 +185,7 @@ async function register (server, options) {
           queryParams: options.logQueryParams ? request.query : undefined,
           pathParams: options.logPathParams ? request.params : undefined,
           tags: options.logRouteTags ? request.route.settings.tags : undefined,
+          err: options.log4xxResponseErrors && (statusCode >= 400 && statusCode < 500) ? request.response.source : undefined,
           res: request.raw.res,
           responseTime
         },

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   ],
   "license": "MIT",
   "devDependencies": {
+    "@hapi/boom": "^10.0.1",
     "@hapi/code": "^9.0.0",
     "@hapi/hapi": "^21.0.0",
     "@hapi/lab": "^25.0.0",


### PR DESCRIPTION
Fixes #111 

This PR adds a new option `log4xxResponseErrors` that, when true, will add the error details to the response log under the key `err` (chosen to match 500 error logging).

For example:

```
{"level":30,"time":1683229159104,"pid":92186,"hostname":"jeff-MacBook-Pro","req":{"id":"1683229159103:jeff-MacBook-Pro:92186:lh9j6jej:10000","method":"get","url":"/","query":{},"headers":{"user-agent":"shot","host":"jeff-MacBook-Pro:0"},"remoteAddress":"127.0.0.1","remotePort":""},"err":{"type":"Object","message":"invalid request","stack":"","statusCode":400,"error":"Bad Request"},"res":{"statusCode":400,"headers":{"content-type":"application/json; charset=utf-8","cache-control":"no-cache","content-length":68}},"responseTime":1,"msg":"[response] get / 400 (1ms)"}
```

This pulls the response from the `request.response.source` object, which is the [value returned by the lifecycle method](https://hapi.dev/api/?v=19.2.1#-responsesource).