### PR TITLE
add logResponsePayload option to log response returned value

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,11 +120,11 @@ events"](#hapievents) section.
 
   When enabled, responses with status codes in the 400-500 range will have the value returned by the hapi lifecycle method added to the `response` event log as `err`.
 
-### `options.logReturnedValue: boolean`
+### `options.logResponsePayload: boolean`
 
   **Default**: `false`
 
-  When enabled, add the response returned value (Hapi `request.response.source`) as `returnedValue` to the `response` event log.
+  When enabled, add the response returned value (Hapi `request.response.source`) as `responsePayload` to the `response` event log.
 
 ### `options.logRequestStart: boolean | (Request) => boolean`
 

--- a/README.md
+++ b/README.md
@@ -120,6 +120,12 @@ events"](#hapievents) section.
 
   When enabled, responses with status codes in the 400-500 range will have the value returned by the hapi lifecycle method added to the `response` event log as `err`.
 
+### `options.logReturnedValue: boolean`
+
+  **Default**: `false`
+
+  When enabled, add the response returned value (Hapi `request.response.source`) as `returnedValue` to the `response` event log.
+
 ### `options.logRequestStart: boolean | (Request) => boolean`
 
   **Default**: false

--- a/index.js
+++ b/index.js
@@ -191,6 +191,7 @@ async function register (server, options) {
           tags: options.logRouteTags ? request.route.settings.tags : undefined,
           err: options.log4xxResponseErrors && (statusCode >= 400 && statusCode < 500) ? request.response.source : undefined,
           res: request.raw.res,
+          returnedValue: options.logReturnedValue && request.response && request.response.source !== undefined ? request.response.source : undefined,
           responseTime
         },
         requestCompleteMessage(request, responseTime)

--- a/index.js
+++ b/index.js
@@ -191,7 +191,7 @@ async function register (server, options) {
           tags: options.logRouteTags ? request.route.settings.tags : undefined,
           err: options.log4xxResponseErrors && (statusCode >= 400 && statusCode < 500) ? request.response.source : undefined,
           res: request.raw.res,
-          returnedValue: options.logReturnedValue && request.response && request.response.source !== undefined ? request.response.source : undefined,
+          responsePayload: options.logResponsePayload && request.response && request.response.source !== undefined ? request.response.source : undefined,
           responseTime
         },
         requestCompleteMessage(request, responseTime)

--- a/test.js
+++ b/test.js
@@ -1587,6 +1587,60 @@ experiment('options.logRequestComplete', () => {
   })
 })
 
+experiment('options.logReturnedValue', () => {
+  test('when options.logReturnedValue is true, the response returned value should be added to the log as "returnedValue"', async () => {
+    const server = getServer()
+
+    let done
+
+    const finish = new Promise(function (resolve, reject) {
+      done = resolve
+    })
+
+    server.route({
+      path: '/',
+      method: 'GET',
+      handler: async (req, h) => {
+        return { foo: 100 }
+      }
+    })
+
+    await registerWithOptionsSink(server, { level: 'info', logReturnedValue: true }, data => {
+      expect(data.returnedValue).to.be.equals({ foo: 100 })
+      done()
+    })
+
+    await server.inject('/')
+    await finish
+  })
+
+  test('when options.logReturnedValue is omitted, "returnedValue" should not be added to the response event log', async () => {
+    const server = getServer()
+
+    let done
+
+    const finish = new Promise(function (resolve, reject) {
+      done = resolve
+    })
+
+    server.route({
+      path: '/',
+      method: 'GET',
+      handler: async (req, h) => {
+        return { foo: 101 }
+      }
+    })
+
+    await registerWithOptionsSink(server, { level: 'info' }, data => {
+      expect(data.returnedValue).to.be.undefined()
+      done()
+    })
+
+    await server.inject('/')
+    await finish
+  })
+})
+
 experiment('logging with mergeHapiLogData option enabled', () => {
   test("log event data is merged into pino's log object", async () => {
     const server = getServer()

--- a/test.js
+++ b/test.js
@@ -1587,8 +1587,8 @@ experiment('options.logRequestComplete', () => {
   })
 })
 
-experiment('options.logReturnedValue', () => {
-  test('when options.logReturnedValue is true, the response returned value should be added to the log as "returnedValue"', async () => {
+experiment('options.logResponsePayload', () => {
+  test('when options.logResponsePayload is true, the response returned value should be added to the log as "responsePayload"', async () => {
     const server = getServer()
 
     let done
@@ -1605,8 +1605,8 @@ experiment('options.logReturnedValue', () => {
       }
     })
 
-    await registerWithOptionsSink(server, { level: 'info', logReturnedValue: true }, data => {
-      expect(data.returnedValue).to.be.equals({ foo: 100 })
+    await registerWithOptionsSink(server, { level: 'info', logResponsePayload: true }, data => {
+      expect(data.responsePayload).to.be.equals({ foo: 100 })
       done()
     })
 
@@ -1614,7 +1614,7 @@ experiment('options.logReturnedValue', () => {
     await finish
   })
 
-  test('when options.logReturnedValue is omitted, "returnedValue" should not be added to the response event log', async () => {
+  test('when options.logResponsePayload is omitted, "responsePayload" should not be added to the response event log', async () => {
     const server = getServer()
 
     let done
@@ -1632,7 +1632,7 @@ experiment('options.logReturnedValue', () => {
     })
 
     await registerWithOptionsSink(server, { level: 'info' }, data => {
-      expect(data.returnedValue).to.be.undefined()
+      expect(data.responsePayload).to.be.undefined()
       done()
     })
 


### PR DESCRIPTION
This PR adds a new option `logResponsePayload` that, when true, adds the response returned value (Hapi `request.response.source` - [Docs](https://hapi.dev/api/?v=19.2.1#-responsesource) ) as `responsePayload` to the `response` event log. 

Please, note that this information is not present at the NodeJS `res` object that nowadays is being logged.
This is useful when we want to track the returned response of our server

